### PR TITLE
Add option to delete local COGs after upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,17 @@ Para cargar una colección de capas, ejecuta el siguiente comando:
 python src/main.py create -f folder_name [-c collection_name]
 ```
 
-### Parámetros:
-- `-f, --folder` (obligatorio): Directorio con el archivo collection.json y las capas.
-- `-c, --collection` (opcional): Nombre de la colección. Si no se proporciona, se tomará el `id` del archivo collection.json.
 
-#### Ejemplo:
+### Parámetros:
+- `-f, --folder` (obligatorio): Directorio con el archivo `collection.json` y las capas.
+- `-c, --collection` (opcional): Nombre de la colección. Si no se proporciona, se tomará el `id` del archivo `collection.json`.
+- `--delete-local-cog` (opcional): Elimina los COG locales de la carpeta `output/<folder>` después de subirlos exitosamente.  
+  Si la carpeta queda vacía tras la limpieza, también será eliminada.
+
+#### Ejemplos:
 
 * Especificando un nombre de colección:
+
 ```
 python src/main.py create -f my_folder -c MyCollection
 
@@ -106,13 +110,20 @@ o
 
 python src/main.py create --folder my_folder
 ```
+
+* Cargar una colección y eliminar los COG locales después de la carga:
+
+```
+python src/main.py create -f my_folder -c MyCollection --delete-local-cog
+```
 ---
 ## Sobrescribir una Colección Existente
 
 Para sobrescribir una colección existente, ejecuta el siguiente comando:
 
+```
 python src/main.py create -f folder_name [-c collection_name] [-o]
-
+```
 
 ### Parámetros:
 - `-f, --folder` (obligatorio): Directorio con el archivo `collection.json` y las capas.

--- a/src/main.py
+++ b/src/main.py
@@ -138,7 +138,7 @@ def main():
 
         collection.convert_layers(
             input_folder, output_dir
-        )  # hace skip si existe
+        )
         logger.info("Layers converted successfully.")
 
         collection.upload_layers(output_dir)

--- a/src/main.py
+++ b/src/main.py
@@ -136,9 +136,7 @@ def main():
 
         output_dir = f"{getcwd()}/output/{args.folder}"
 
-        collection.convert_layers(
-            input_folder, output_dir
-        )
+        collection.convert_layers(input_folder, output_dir)
         logger.info("Layers converted successfully.")
 
         collection.upload_layers(output_dir)

--- a/src/main.py
+++ b/src/main.py
@@ -59,6 +59,14 @@ def main():
         required=False,
     )
 
+    create_parser.add_argument(
+        "--delete-local-cog",
+        dest="delete_local_cog",
+        action="store_true",
+        help="(Opcional) Elimina los COG locales en la carpeta de salida luego de subirlos",
+        required=False,
+    )
+
     validate_parser = sub_parsers.add_parser(
         "validate", help="Validate collection specification"
     )
@@ -127,7 +135,10 @@ def main():
             logger.info("Previous collection removed.")
 
         output_dir = f"{getcwd()}/output/{args.folder}"
-        collection.convert_layers(input_folder, output_dir)
+
+        collection.convert_layers(
+            input_folder, output_dir
+        )  # hace skip si existe
         logger.info("Layers converted successfully.")
 
         collection.upload_layers(output_dir)
@@ -135,6 +146,9 @@ def main():
 
         collection.upload_collection()
         logger.info("Collection uploaded successfully.")
+
+        if args.delete_local_cog:
+            collection.clean_local_cogs(output_dir)
 
         sysexit("Process completed successfully.")
 

--- a/src/utils/storage.py
+++ b/src/utils/storage.py
@@ -39,7 +39,7 @@ class Storage:
         container_name = self.container_client.container_name
 
         if file_path.startswith(f"{container_name}/"):
-            file_path = file_path[len(f"{container_name}/") :]
+            file_path = file_path[len(f"{container_name}/"):]
 
         blob_client = self.container_client.get_blob_client(file_path)
 


### PR DESCRIPTION
## 🛠️ Changes
Introduces the --delete-local-cog flag to remove local COG files and their output directory after successful upload. Updates collection.py with a clean_local_cogs method, improves conversion and upload logic, and updates documentation and CLI argument parsing accordingly.

## 📝 Associated issues
Resolve [LIB-278](https://linear.app/biodev/issue/LIB-278/cambio-en-comportamiento-por-defecto-para-creacion-de-coleccion)


