### PR TITLE
Agregar propiedad para identificar si colección es clasificada o continua

### DIFF
--- a/docs/gen_pages.py
+++ b/docs/gen_pages.py
@@ -7,13 +7,14 @@ commands_dir = os.path.join("docs", "commands")
 
 summary_lines = ["- [Inicio](index.md)\n", "- Comandos\n"]
 
+
 def gen_files():
     """
     Generate md files from yml files.
     """
     with open(template_path, "r", encoding="utf-8") as tpl:
         template_content = tpl.read()
-    
+
     for fname in sorted(os.listdir(commands_dir)):
         if fname.endswith(".yml"):
             name = os.path.splitext(fname)[0]
@@ -21,10 +22,11 @@ def gen_files():
 
             with mkdocs_gen_files.open(md_file, "w") as f:
                 f.write(template_content)
-            
+
             summary_lines.append(f"    - [{name.capitalize()}]({md_file})\n")
 
     with mkdocs_gen_files.open("summary.md", "w") as f:
         f.writelines(summary_lines)
+
 
 gen_files()

--- a/docs/main.py
+++ b/docs/main.py
@@ -1,5 +1,5 @@
 def define_env(env):
-    
+
     import os, yaml
 
     base_path = os.path.join(env.project_dir, "docs", "commands")

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - rasterio>=1.3.9,<1.4.0
   - shapely>=2.0.3,<2.1.0
   - jsonschema>=4.21.0,<4.22.0
-  - pystac>=1.9.0,<1.10.0
+  - pystac==1.9.0
   - pydantic-settings>=2.2.1,<2.3.0
   - azure-storage-blob>=12.19.1,<12.20.0
   - pip

--- a/spec/collection.example.json
+++ b/spec/collection.example.json
@@ -3,6 +3,7 @@
   "title": "Time series of the binary presence of forests in Colombia",
   "description": "Time series of the binary presence of forests in Colombia. Bosque/Non Bosque. With 1 indicating the presence of forests.",
   "metadata": {
+    "data_type": "Clasificada",
     "properties": {
       "values": [0, 1, 2],
       "colors": ["#c65453", "#92ab58", "#c5b599"],

--- a/spec/collection.json
+++ b/spec/collection.json
@@ -36,6 +36,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "class": {
+              "type": "string"
             }
           },
           "required": [

--- a/spec/collection.json
+++ b/spec/collection.json
@@ -13,6 +13,9 @@
     "metadata": {
       "type": "object",
       "properties": {
+        "data_type": {
+          "type": "string"          
+        },
         "properties": {
           "type": "object",
           "properties": {
@@ -20,6 +23,12 @@
               "type": "array",
               "items": {
                 "type": "number"
+              }
+            },
+            "colors": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
             "classes": {
@@ -31,7 +40,7 @@
           },
           "required": [
             "values",
-            "classes"
+            "colors"
           ]
         }
       }

--- a/spec/collection.md
+++ b/spec/collection.md
@@ -8,10 +8,12 @@ La descripción de las colecciones a cargar se debe hacer siguiendo la siguiente
 | title | string | Título de la colección | Sí | |
 | description | string | Descripción de la colección | Sí | |
 | metadata | object | Objeto con información o datos extra relacionados con todos los items de la colección | Sí | |
-| _metadata.properties_ | object | objeto que relaciona tuplas de información con los valores de los items. | No | Todos los atributos de este objeto son arreglos y __deben tener la misma cantidad de elementos__ |
-| _metadata.properties.values_ | array | tupla con los diferentes valores que pueden existir en el raster de cada item | Sí | Es requerido si existe el atributo _metadata.properties_ |
-| _metadata.properties.classes_ | array | tupla con los nombres de las clases correspondientes a los valores de _metadata.properties.values_ | Sí | Es requerido si existe el atributo _metadata.properties_ |
-| _metadata.properties.[otro]_ | array | tupla con [otro] datos para complementar la interpretación de los valores que pueden existir en el raster de cada item | No | Un ejemplo puede ser _colors_, para asociar colores a los valores y clases del raster |
+| metadata.data_type | string | Tipo de datos de la colección (`Clasificada` o `Continua`) | Sí | Determina el tipo de colección, de acuerdo al formato y lectura de sus propiedades |
+| _metadata.properties_ | object | objeto que relaciona tuplas de información con los valores de los items. | No | Todos los atributos de este objeto __deben ser arreglos y deben tener la misma cantidad de elementos si el tipo de datos es `Clasificada`__ |
+| _metadata.properties.colors_ | array | tupla con los códigos de colores correspondientes a los valores de _metadata.properties.values_ si la colección es `Clasificada` o con valores máximo, intermedio y mínimo si la colección es `Continua` | Sí | Si la colección es `Continua`, la lista deberá contener 3 elementos |
+| _metadata.properties.values_ | array | tupla con los diferentes valores que pueden existir en el raster de cada item si la colección es `Clasificada` o con valores máximo y mínimo si la colección es `Continua` | Sí | Si la colección es `Continua`, la lista deberá contener 2 elementos |
+| _metadata.properties.classes_ | array | tupla con los nombres de las clases correspondientes a los valores de _metadata.properties.values_ | Sí | Es requerido si la colección es de tipo `Clasificada` |
+| _metadata.properties.class_ | string | indica el valor que se está midiendo | Sí | Es requerido si si la colección es de tipo `Continua` |
 | items | array | Información de cada uno de los rasters a cargar a la colección | Sí | Este atributo es un arreglo de objetos, donde cada objeto tiene los atributos que se describen más abajo |
 | _[item].id_ |  string | Id del item | Sí | |
 | _[item].year_ |  string | Año asociado al item | Sí | |

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -71,9 +71,6 @@ def validate_format(data):
                         )
 
                 if data_type_enum == CollectionDataType.CONTINUOUS:
-                    properties_values = data["metadata"]["properties"][
-                        "values"
-                    ]
 
                     properties = {
                         "values": data["metadata"]["properties"]["values"],
@@ -87,9 +84,9 @@ def validate_format(data):
                                 "El elemento debe ser una lista."
                             )
 
-                    if not "class" in data["metadata"]["properties"]:
+                    if "class" not in data["metadata"]["properties"]:
                         raise FormatError(
-                            f"Error en el metadato de la colección 'metadata.properties.class': "
+                            "Error en el metadato de la colección 'metadata.properties.class': "
                             "El elemento no existe."
                         )
 
@@ -99,13 +96,13 @@ def validate_format(data):
 
                     if len(properties["colors"]) != 3:
                         raise FormatError(
-                            f"Error en el metadato de la colección 'metadata.properties.colors': "
+                            "Error en el metadato de la colección 'metadata.properties.colors': "
                             "La lista debe tener 3 elementos."
                         )
 
                     if len(properties["values"]) != 2:
                         raise FormatError(
-                            f"Error en el metadato de la colección 'metadata.properties.values': "
+                            "Error en el metadato de la colección 'metadata.properties.values': "
                             "La lista debe tener 2 elementos."
                         )
 

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -108,7 +108,7 @@ def validate_format(data):
 
                     if not isinstance(properties["class"], str):
                         raise FormatError(
-                            f"Error en el metadato de la colección 'metadata.properties.class': "
+                            "Error en el metadato de la colección 'metadata.properties.class': "
                             "El elemento debe ser una cadena de texto."
                         )
 

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -43,16 +43,78 @@ def validate_format(data):
             if data_type not in data_type_values:
                 raise FormatError(data_type_error)
 
+            data_type_enum = CollectionDataType(data_type)
+
             if "properties" in data["metadata"]:
-                metadata_properties_lengths = [
-                    len(data["metadata"]["properties"][key])
-                    for key in data["metadata"]["properties"]
-                ]
-                if len(set(metadata_properties_lengths)) != 1:
-                    raise FormatError(
-                        "Error en las propiedades de la colección: "
-                        "Los elementos dentro de 'metadata.properties' no tienen la misma longitud."
-                    )
+                if data_type_enum == CollectionDataType.CLASSIFIED:
+                    properties = {
+                        "values": data["metadata"]["properties"]["values"],
+                        "colors": data["metadata"]["properties"]["colors"],
+                        "classes": data["metadata"]["properties"]["classes"],
+                    }
+
+                    for property_name in properties:
+                        if not isinstance(properties[property_name], list):
+                            raise FormatError(
+                                f"Error en el metadato de la colección 'metadata.properties.{property_name}': "
+                                "El elemento debe ser una lista."
+                            )
+
+                    metadata_properties_lengths = [
+                        len(data["metadata"]["properties"][property_name])
+                        for property_name in properties
+                    ]
+
+                    if len(set(metadata_properties_lengths)) != 1:
+                        raise FormatError(
+                            "Error en las propiedades de la colección: "
+                            "Los elementos dentro de 'metadata.properties' no tienen la misma longitud."
+                        )
+
+                if data_type_enum == CollectionDataType.CONTINUOUS:
+                    properties_values = data["metadata"]["properties"][
+                        "values"
+                    ]
+
+                    properties = {
+                        "values": data["metadata"]["properties"]["values"],
+                        "colors": data["metadata"]["properties"]["colors"],
+                    }
+
+                    for property_name in properties:
+                        if not isinstance(properties[property_name], list):
+                            raise FormatError(
+                                f"Error en el metadato de la colección 'metadata.properties.{property_name}': "
+                                "El elemento debe ser una lista."
+                            )
+
+                    if not "class" in data["metadata"]["properties"]:
+                        raise FormatError(
+                            f"Error en el metadato de la colección 'metadata.properties.class': "
+                            "El elemento no existe."
+                        )
+
+                    properties["class"] = data["metadata"]["properties"][
+                        "class"
+                    ]
+
+                    if len(properties["colors"]) != 3:
+                        raise FormatError(
+                            f"Error en el metadato de la colección 'metadata.properties.colors': "
+                            "La lista debe tener 3 elementos."
+                        )
+
+                    if len(properties["values"]) != 2:
+                        raise FormatError(
+                            f"Error en el metadato de la colección 'metadata.properties.values': "
+                            "La lista debe tener 2 elementos."
+                        )
+
+                    if not isinstance(properties["class"], str):
+                        raise FormatError(
+                            f"Error en el metadato de la colección 'metadata.properties.class': "
+                            "El elemento debe ser una cadena de texto."
+                        )
 
     except Exception as e:
         raise FormatError(

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -1,7 +1,13 @@
+from enum import Enum
 from json import load
 from os import listdir, path
 
 from jsonschema import FormatError, validate
+
+
+class CollectionDataType(Enum):
+    CONTINUOUS = "Continua"
+    CLASSIFIED = "Clasificada"
 
 
 def validate_input_folder(folder):
@@ -24,16 +30,29 @@ def validate_format(data):
     try:
         validate(instance=data, schema=schema)
 
-        if "metadata" in data and "properties" in data["metadata"]:
-            metadata_properties_lengths = [
-                len(data["metadata"]["properties"][key])
-                for key in data["metadata"]["properties"]
+        if "metadata" in data:
+            data_type_values = [
+                data_type.value for data_type in CollectionDataType
             ]
-            if len(set(metadata_properties_lengths)) != 1:
-                raise FormatError(
-                    "Error en las propiedades de la colección: "
-                    "Los elementos dentro de 'metadata.properties' no tienen la misma longitud."
-                )
+            data_type_error = f"Error en el tipo de dato de la colección 'metadata.data_type': \nEl elemento debe tener uno de estos valores: {data_type_values}"
+
+            if "data_type" not in data["metadata"]:
+                raise FormatError(data_type_error)
+
+            data_type = data["metadata"]["data_type"]
+            if data_type not in data_type_values:
+                raise FormatError(data_type_error)
+
+            if "properties" in data["metadata"]:
+                metadata_properties_lengths = [
+                    len(data["metadata"]["properties"][key])
+                    for key in data["metadata"]["properties"]
+                ]
+                if len(set(metadata_properties_lengths)) != 1:
+                    raise FormatError(
+                        "Error en las propiedades de la colección: "
+                        "Los elementos dentro de 'metadata.properties' no tienen la misma longitud."
+                    )
 
     except Exception as e:
         raise FormatError(

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -34,14 +34,13 @@ def validate_format(data):
             data_type_values = [
                 data_type.value for data_type in CollectionDataType
             ]
-            data_type_error = f"Error en el tipo de dato de la colección 'metadata.data_type': \nEl elemento debe tener uno de estos valores: {data_type_values}"
-
-            if "data_type" not in data["metadata"]:
-                raise FormatError(data_type_error)
 
             data_type = data["metadata"]["data_type"]
             if data_type not in data_type_values:
-                raise FormatError(data_type_error)
+                raise FormatError(
+                    "Error en el tipo de dato de la colección 'metadata.data_type': "
+                    f"El elemento debe tener uno de estos valores: {data_type_values}"
+                )
 
             data_type_enum = CollectionDataType(data_type)
 

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -52,13 +52,6 @@ def validate_format(data):
                         "classes": data["metadata"]["properties"]["classes"],
                     }
 
-                    for property_name in properties:
-                        if not isinstance(properties[property_name], list):
-                            raise FormatError(
-                                f"Error en el metadato de la colección 'metadata.properties.{property_name}': "
-                                "El elemento debe ser una lista."
-                            )
-
                     metadata_properties_lengths = [
                         len(data["metadata"]["properties"][property_name])
                         for property_name in properties
@@ -72,44 +65,22 @@ def validate_format(data):
 
                 if data_type_enum == CollectionDataType.CONTINUOUS:
 
-                    properties = {
-                        "values": data["metadata"]["properties"]["values"],
-                        "colors": data["metadata"]["properties"]["colors"],
-                    }
-
-                    for property_name in properties:
-                        if not isinstance(properties[property_name], list):
-                            raise FormatError(
-                                f"Error en el metadato de la colección 'metadata.properties.{property_name}': "
-                                "El elemento debe ser una lista."
-                            )
-
                     if "class" not in data["metadata"]["properties"]:
                         raise FormatError(
                             "Error en el metadato de la colección 'metadata.properties.class': "
                             "El elemento no existe."
                         )
 
-                    properties["class"] = data["metadata"]["properties"][
-                        "class"
-                    ]
-
-                    if len(properties["colors"]) != 3:
+                    if len(data["metadata"]["properties"]["colors"]) != 3:
                         raise FormatError(
                             "Error en el metadato de la colección 'metadata.properties.colors': "
                             "La lista debe tener 3 elementos."
                         )
 
-                    if len(properties["values"]) != 2:
+                    if len(data["metadata"]["properties"]["values"]) != 2:
                         raise FormatError(
                             "Error en el metadato de la colección 'metadata.properties.values': "
                             "La lista debe tener 2 elementos."
-                        )
-
-                    if not isinstance(properties["class"], str):
-                        raise FormatError(
-                            "Error en el metadato de la colección 'metadata.properties.class': "
-                            "El elemento debe ser una cadena de texto."
                         )
 
     except Exception as e:

--- a/src/utils/storage.py
+++ b/src/utils/storage.py
@@ -39,7 +39,7 @@ class Storage:
         container_name = self.container_client.container_name
 
         if file_path.startswith(f"{container_name}/"):
-            file_path = file_path[len(f"{container_name}/") :]
+            file_path = file_path[len(f"{container_name}/"):]
 
         blob_client = self.container_client.get_blob_client(file_path)
 

--- a/src/utils/storage.py
+++ b/src/utils/storage.py
@@ -39,7 +39,7 @@ class Storage:
         container_name = self.container_client.container_name
 
         if file_path.startswith(f"{container_name}/"):
-            file_path = file_path[len(f"{container_name}/"):]
+            file_path = file_path[len(f"{container_name}/") :]
 
         blob_client = self.container_client.get_blob_client(file_path)
 


### PR DESCRIPTION
## 🛠️ Cambios
- Agregadas propiedades para definir tipos de colecciones (clasificadas o continuas)

## 📝 Tareas asociadas
Resuelve lib-326

## 🤔 Consideraciones

Para simular una colección continua, he copiado los archivos de coberturas y en el archivo "collection.json" he agregado este contenido:

```json
{
  "id": "Test",
  "title": "Test",
  "description": "Test",
  "metadata": {
    "data_type": "Continua",
    "properties":
    {
      "values": [
        1,
        2
      ],
      "colors": [
        "#60BBD4",
        "#164F74",
        "#5AA394"
      ],
      "class": "vacíos"
    }
  },
  "items": [
    {
      "id": "2020",
      "year": "2020",
      "assets": {
        "input_file": "CLC_clases_2020.tif"
      }
    }
  ]
}
```