### PR TITLE
Add projection EPSG support to collection metadata

### DIFF
--- a/spec/collection.example.json
+++ b/spec/collection.example.json
@@ -4,6 +4,9 @@
   "description": "Time series of the binary presence of forests in Colombia. Bosque/Non Bosque. With 1 indicating the presence of forests.",
   "metadata": {
     "data_type": "Clasificada",
+    "projection": {
+      "epsg": 4326
+    },
     "properties": {
       "values": [0, 1, 2],
       "colors": ["#c65453", "#92ab58", "#c5b599"],

--- a/spec/collection.json
+++ b/spec/collection.json
@@ -16,6 +16,18 @@
         "data_type": {
           "type": "string"          
         },
+        "projection": {
+          "type": "object",
+          "properties": {
+            "epsg": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "epsg"
+          ]
+        },
         "properties": {
           "type": "object",
           "properties": {

--- a/spec/collection.md
+++ b/spec/collection.md
@@ -8,9 +8,14 @@ La descripción de las colecciones a cargar se debe hacer siguiendo la siguiente
 | title | string | Título de la colección | Sí | |
 | description | string | Descripción de la colección | Sí | |
 | metadata | object | Objeto con información o datos extra relacionados con todos los items de la colección | Sí | |
-| _metadata.properties_ | object | objeto que relaciona tuplas de información con los valores de los items. | No | Todos los atributos de este objeto son arreglos y __deben tener la misma cantidad de elementos__ |
-| _metadata.properties.values_ | array | tupla con los diferentes valores que pueden existir en el raster de cada item | Sí | Es requerido si existe el atributo _metadata.properties_ |
-| _metadata.properties.classes_ | array | tupla con los nombres de las clases correspondientes a los valores de _metadata.properties.values_ | Sí | Es requerido si existe el atributo _metadata.properties_ |
+| metadata.data_type | string | Tipo de datos de la colección (`Clasificada` o `Continua`) | Sí | Determina el tipo de colección, de acuerdo al formato y lectura de sus propiedades |
+| metadata.projection | object | Información sobre la proyección de la colección | No | Solo si se necesita especificar la proyección de la colección |
+| metadata.projection.epsg | integer | Código EPSG de la proyección (mínimo 1) | Sí | Es requerido si existe el objeto _metadata.projection_ |
+| _metadata.properties_ | object | objeto que relaciona tuplas de información con los valores de los items. | No | Todos los atributos de este objeto son arreglos y __deben tener la misma cantidad de elementos si el tipo de datos es `Clasificada`__ |
+| _metadata.properties.values_ | array | tupla con los diferentes valores que pueden existir en el raster de cada item si la colección es `Clasificada` o con valores máximo y mínimo si la colección es `Continua` | Sí | Si la colección es `Continua`, la lista deberá contener 2 elementos |
+| _metadata.properties.colors_ | array | tupla con los códigos de colores correspondientes a los valores de _metadata.properties.values_ si la colección es `Clasificada` o con valores máximo, intermedio y mínimo si la colección es `Continua` | Sí | Si la colección es `Continua`, la lista deberá contener 3 elementos |
+| _metadata.properties.classes_ | array | tupla con los nombres de las clases correspondientes a los valores de _metadata.properties.values_ | Sí | Es requerido si la colección es de tipo `Clasificada` |
+| _metadata.properties.class_ | string | indica el valor que se está midiendo | Sí | Es requerido si la colección es de tipo `Continua` |
 | _metadata.properties.[otro]_ | array | tupla con [otro] datos para complementar la interpretación de los valores que pueden existir en el raster de cada item | No | Un ejemplo puede ser _colors_, para asociar colores a los valores y clases del raster |
 | items | array | Información de cada uno de los rasters a cargar a la colección | Sí | Este atributo es un arreglo de objetos, donde cada objeto tiene los atributos que se describen más abajo |
 | _[item].id_ |  string | Id del item | Sí | |

--- a/src/collection.py
+++ b/src/collection.py
@@ -138,6 +138,17 @@ class Collection:
             else collection_data["id"]
         )
 
+        if "projection" not in collection_data["metadata"] and self.items:
+            first_item = self.items[0]
+            if "proj:epsg" in first_item["properties"]:
+                collection_data["metadata"]["projection"] = {
+                    "epsg": first_item["properties"]["proj:epsg"]
+                }
+                logger.info(
+                    f"Extracted projection EPSG:{first_item['properties']['proj:epsg']} "
+                    f"from first item {first_item['id']} for collection"
+                )
+
         self.stac_collection = pystac.Collection(
             id=collection_id,
             title=collection_data["title"],

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -31,6 +31,19 @@ def validate_format(data):
         validate(instance=data, schema=schema)
 
         if "metadata" in data:
+            if "projection" in data["metadata"]:
+                projection = data["metadata"]["projection"]
+                if "epsg" not in projection:
+                    raise FormatError(
+                        "Error en la proyección de la colección 'metadata.projection.epsg': "
+                        "El elemento es requerido."
+                    )
+                if not isinstance(projection["epsg"], int) or projection["epsg"] < 1:
+                    raise FormatError(
+                        "Error en la proyección de la colección 'metadata.projection.epsg': "
+                        "Debe ser un número entero positivo."
+                    )
+
             data_type_values = [
                 data_type.value for data_type in CollectionDataType
             ]

--- a/src/utils/spec.py
+++ b/src/utils/spec.py
@@ -38,7 +38,10 @@ def validate_format(data):
                         "Error en la proyección de la colección 'metadata.projection.epsg': "
                         "El elemento es requerido."
                     )
-                if not isinstance(projection["epsg"], int) or projection["epsg"] < 1:
+                if (
+                    not isinstance(projection["epsg"], int)
+                    or projection["epsg"] < 1
+                ):
                     raise FormatError(
                         "Error en la proyección de la colección 'metadata.projection.epsg': "
                         "Debe ser un número entero positivo."


### PR DESCRIPTION
## 🛠️ Changes
Introduces a 'projection' field with EPSG code to collection metadata and schema. Automatically extracts EPSG from the first item's properties if not present. Updates validation to enforce presence and type of 'metadata.projection.epsg'.

## 📝 Associated issues
Resolve [LIB-387](https://linear.app/biodev/issue/LIB-387/agregar-informacion-de-proyeccion-a-la-especificacion-de-coleccion)

## ✅ Checks
- [X] Verify that the docs has been updated according to the changes in this PR